### PR TITLE
Fixing #10910  function `reconstruct_from_patches_2d ` bug

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -430,14 +430,13 @@ def reconstruct_from_patches_2d(patches, image_size):
     n_w = i_w - p_w + 1
     for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
         img[i:i + p_h, j:j + p_w] += p
-
-    for i in range(i_h):
-        for j in range(i_w):
-            # divide by the amount of overlap
-            # XXX: is this the most efficient way? memory-wise yes, cpu wise?
-            img[i, j] /= float(min(i + 1, p_h, i_h - i) *
-                               min(j + 1, p_w, i_w - j))
-    return img
+    # generate an overlap count map directly, this is fast
+    Y, X = np.ogrid[0:i_h, 0:i_w]
+    x_h = min(p_w, i_w - p_w)
+    y_h = min(p_h, i_h - p_h)
+    overlap_cnt = ((np.minimum(np.minimum(X+1,x_h), np.minimum(i_w-X,x_h)))
+                  *(np.minimum(np.minimum(Y+1,y_h), np.minimum(i_h-Y,y_h))))
+    return img/overlap_cnt
 
 
 class PatchExtractor(BaseEstimator):

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -432,12 +432,9 @@ def reconstruct_from_patches_2d(patches, image_size):
         img[i:i + p_h, j:j + p_w] += p
     # generate an overlap count map directly, this is fast
     Y, X = np.ogrid[0:i_h, 0:i_w]
-    x_h = min(p_w, i_w - p_w)
-    y_h = min(p_h, i_h - p_h)
-    if x_h == i_w - p_w:
-        x_h = x_h + 1
-    if y_h == i_h - p_h:
-        y_h - y_h + 1
+    x_h = min(p_w, i_w - p_w + 1)
+    y_h = min(p_h, i_h - p_h + 1)
+
     overlap_cnt = ((np.minimum(np.minimum(X+1,x_h), np.minimum(i_w-X,x_h)))
                   *(np.minimum(np.minimum(Y+1,y_h), np.minimum(i_h-Y,y_h))))
     return img/overlap_cnt

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -434,6 +434,10 @@ def reconstruct_from_patches_2d(patches, image_size):
     Y, X = np.ogrid[0:i_h, 0:i_w]
     x_h = min(p_w, i_w - p_w)
     y_h = min(p_h, i_h - p_h)
+    if x_h == i_w - p_w:
+        x_h = x_h + 1
+    if y_h == i_h - p_h:
+        y_h - y_h + 1
     overlap_cnt = ((np.minimum(np.minimum(X+1,x_h), np.minimum(i_w-X,x_h)))
                   *(np.minimum(np.minimum(Y+1,y_h), np.minimum(i_h-Y,y_h))))
     return img/overlap_cnt


### PR DESCRIPTION
Elementwise average (nested for loops)  was replaced by overlap count map.  divide the overlap map directly is fast. Also #10910 should be fixed...

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
 Fixes #10910


#### What does this implement/fix? Explain your changes.

I created an overlap count map for reconstruction map. Pay careful attention to edges of the overlap count map, which corresponds to the number of elements has been add to that pixel position.  

#### Any other comments?
This is my first time pull request on GitHub... Any mistake, please update to me... 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
